### PR TITLE
Feature/bedrock haiku 4 5

### DIFF
--- a/summary_all.py
+++ b/summary_all.py
@@ -6,7 +6,7 @@ import boto3
 
 
 bedrock_client = boto3.client(service_name="bedrock-runtime", region_name="us-east-1")
-model_id = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+model_id = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 
 # prompt/以下のファイル名をすべて取得する関数

--- a/summary_all.py
+++ b/summary_all.py
@@ -6,7 +6,7 @@ import boto3
 
 
 bedrock_client = boto3.client(service_name="bedrock-runtime", region_name="us-east-1")
-model_id = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+model_id = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
 # prompt/以下のファイル名をすべて取得する関数
@@ -54,7 +54,6 @@ def generate_summary(prompt: str) -> str:
     # 推論設定
     inference_config = {
         "temperature": settings.temperature,
-        "topP": settings.top_p,
         "maxTokens": settings.max_tokens,
         "stopSequences": [],
     }


### PR DESCRIPTION
 PR-B: Bedrockのモデルを Claude Haiku 4.5 に更新
  ## 変更内容

  - `model_id` を `anthropic.claude-3-5-sonnet-20240620-v1:0`
  から `us.anthropic.claude-haiku-4-5-20251001-v1:0` に更新
  - Claude 4.x 系は on-demand
  スループット非対応のため、クロスリージョン推論プロファイル
  (`us.` プレフィックス) を使用
  - Claude 4.x 系では `temperature` と `topP` の同時指定が
  `ValidationException` になるため、`inference_config` から
  `topP` を削除

  ## 効果

  要約タスクの品質を保ったまま、3.5 Sonnet 比で大幅に高速・低コ
  ストになります（本プロジェクトのバッチ用途と相性が良い）。
