### PR TITLE
出力形式を docx から Markdown に変更し、章見出しに本のページ範囲を付与

### DIFF
--- a/join_summary.py
+++ b/join_summary.py
@@ -1,29 +1,38 @@
-import docx
+import re
 import pandas as pd
+import settings
 
 
 if __name__ == "__main__":
     # tmp/index.csvを読み込む
     df = pd.read_csv("tmp/index.csv")
 
-    # docxを新規作成
-    doc = docx.Document()
+    # split_point.csvから章ごとの本のページ範囲を計算する
+    split = pd.read_csv("tmp/split_point.csv")
+    page_ajust = settings.first_page - settings.first_page_in_book
+    starts = [p - page_ajust for p in split["page_no"]]
+    ends = [s - 1 for s in starts[1:]] + [settings.last_page - page_ajust]
+    title_to_range = dict(zip(split["char"], zip(starts, ends)))
 
-    for index, row in df.iterrows():
-        # summaryから呼び込むためのファイルパスに変更する
-        summary_path = row["file_name"].replace("prompt", "summary")
+    with open("tmp/summary.md", "w", encoding="utf-8") as out:
+        for _, row in df.iterrows():
+            # summaryから呼び込むためのファイルパスに変更する
+            summary_path = row["file_name"].replace("prompt", "summary")
 
-        # summaryを読み込む
-        with open(summary_path) as f:
-            summary = f.read()
+            # summaryを読み込む
+            with open(summary_path, encoding="utf-8") as f:
+                summary = f.read()
 
-        # もし、titleがnanだったら、見出しを追加しない
-        if not pd.isna(row["title"]):
-            # docxにtitleを追加する
-            doc.add_heading(row["title"], level=1)
+            # モデルが応答に含めがちな「# 要約」「# 出力」ヘッダー行を除去
+            summary = re.sub(r"^#\s*(要約|出力)\s*\n+", "", summary, flags=re.MULTILINE)
 
-        # docxにsummaryを追加する
-        doc.add_paragraph(summary)
+            # titleがある行は章の開始 → 見出しを書く
+            if not pd.isna(row["title"]):
+                title = row["title"]
+                if title in title_to_range:
+                    s, e = title_to_range[title]
+                    out.write(f"# {title} (p.{s}-{e})\n\n")
+                else:
+                    out.write(f"# {title}\n\n")
 
-    # docxを保存する
-    doc.save("tmp/summary.docx")
+            out.write(summary.rstrip() + "\n\n")


### PR DESCRIPTION
- tmp/summary.docx ではなく tmp/summary.md を出力するよう変更
- python-docx への依存を削除（標準ライブラリだけで完結）
- 章見出しに本のページ範囲を「# 章タイトル (p.X-Y)」形式で付与
  - tmp/split_point.csv の page_no から page_ajust を引いて本のページ番号に変換
  - 各章の end は次章 start - 1、最終章は settings.last_page から計算
- モデルが応答冒頭や途中に挿入しがちな「# 要約」「# 出力」ヘッダー行を正規表現で除去（章タイトルと同レベルの見出し衝突を解消）

Markdown 化により、生成後の要約を直接編集したり、エディタや Markdown ビューアで確認しやすくなる。Google Docs へのインポート時も Markdown 形式は標準対応している。